### PR TITLE
Replicate existing IA for tags and speakers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,9 @@
 
 # production
 /build
+/public/categories.json
+/public/speaker-data.json
+/public/tag-data.json
 
 # misc
 .DS_Store

--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
   "scripts": {
     "dev": "next dev",
     "submodules:update": "git submodule update --init && git submodule update --remote",
-    "build": "npm run submodules:update && next build",
+    "fetch-categories": "node scripts/fetchCategories.js",
+    "contentlayer": "contentlayer2 build --clearCache",
+    "build": "npm run submodules:update && npm run fetch-categories && next build",
     "start": "next start",
     "lint": "next lint"
   },

--- a/scripts/fetchCategories.js
+++ b/scripts/fetchCategories.js
@@ -1,0 +1,21 @@
+const fs = require('fs');
+const path = require('path');
+const https = require('https');
+
+const url = 'https://bitcoinops.org/topics.json';
+const outputPath = path.join(__dirname, '..', 'public', 'categories.json');
+
+https.get(url, (res) => {
+  let data = '';
+
+  res.on('data', (chunk) => {
+    data += chunk;
+  });
+
+  res.on('end', () => {
+    fs.writeFileSync(outputPath, data);
+    console.log('Categories data has been fetched and saved to public folder.');
+  });
+}).on('error', (err) => {
+  console.error('Error fetching categories:', err.message);
+});

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,22 +1,22 @@
-import React from "react";
-import { allTranscripts } from "contentlayer/generated";
 import Link from "next/link";
 
-import { organizeContent } from "@/utils";
-
-export default function Home() {
-  const contentTree = organizeContent(allTranscripts);
-
+export default function HomePage() {
   return (
     <div>
       <h1>Bitcoin Transcripts</h1>
-      <ul>
-        {Object.keys(contentTree).map((key) => (
-          <li key={key}>
-            <Link href={`/${key}`}>{key}</Link>
+      <nav>
+        <ul>
+          <li>
+            <Link href="/sources">Sources</Link>
           </li>
-        ))}
-      </ul>
+          <li>
+            <Link href="/tags">Tags</Link>
+          </li>
+          <li>
+            <Link href="/speakers">Speakers</Link>
+          </li>
+        </ul>
+      </nav>
     </div>
   );
 }

--- a/src/app/sources/page.tsx
+++ b/src/app/sources/page.tsx
@@ -1,0 +1,21 @@
+import React from "react";
+import { allTranscripts } from "contentlayer/generated";
+import Link from "next/link";
+import { organizeContent } from "@/utils";
+
+export default function SourcesPage() {
+  const contentTree = organizeContent(allTranscripts);
+
+  return (
+    <div>
+      <h1>Bitcoin Transcripts Sources</h1>
+      <ul>
+        {Object.keys(contentTree).map((key) => (
+          <li key={key}>
+            <Link href={`/${key}`}>{key}</Link>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/src/app/speakers/[speaker]/page.tsx
+++ b/src/app/speakers/[speaker]/page.tsx
@@ -1,0 +1,63 @@
+import React from "react";
+import Link from "next/link";
+import fs from "fs";
+import path from "path";
+import { allTranscripts } from "contentlayer/generated";
+import { getSpeakerData } from "@/utils";
+
+// Generates the paths for static generation
+export async function generateStaticParams() {
+  const filePath = path.join(process.cwd(), "public", "speaker-data.json");
+  const fileContents = fs.readFileSync(filePath, "utf8");
+  const speakerData = JSON.parse(fileContents);
+
+  return Object.keys(speakerData).map((slug) => ({
+    speaker: slug,
+  }));
+}
+
+export default async function SpeakerPage({
+  params,
+}: {
+  params: { speaker: string };
+}) {
+  const { speaker } = params;
+
+  // Get the speaker's full name and count from the JSON file
+  console.log(speaker);
+  const speakerInfo = getSpeakerData(speaker);
+
+  if (!speakerInfo) {
+    return <div>Speaker not found</div>;
+  }
+
+  // Find transcripts where the speaker is mentioned
+  const transcripts = allTranscripts
+    .filter((transcript) =>
+      transcript.speakers?.some((s) => s === speakerInfo.fullName)
+    )
+    .map(({ title, url }) => ({
+      title,
+      url,
+    }));
+
+  return (
+    <div className="container mx-auto px-4 py-8">
+      <h1 className="text-3xl font-bold mb-4">
+        Transcripts featuring "{speakerInfo.fullName}"
+      </h1>
+      <ul className="list-disc pl-5 space-y-2">
+        {transcripts.map((transcript) => (
+          <li key={transcript.url}>
+            <Link
+              className="text-blue-500 hover:underline"
+              href={transcript.url}
+            >
+              {transcript.title}
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/src/app/speakers/page.tsx
+++ b/src/app/speakers/page.tsx
@@ -1,0 +1,45 @@
+import React from "react";
+import Link from "next/link";
+import { getSpeakers } from "@/utils";
+
+interface SpeakerInfo {
+  fullName: string;
+  count: number;
+  slug: string;
+}
+
+export default function SpeakersPage() {
+  const speakerData = getSpeakers();
+
+  // Create the speakers array using the precomputed data
+  const speakers: SpeakerInfo[] = Object.entries(speakerData)
+    .map(([slug, data]) => ({
+      fullName: data.fullName,
+      count: data.count,
+      slug, // Slug is already the key in speakerData
+    }))
+    .sort((a, b) => a.fullName.localeCompare(b.fullName));
+
+  return (
+    <div className="container mx-auto px-4 py-8">
+      <h1 className="text-3xl font-bold mb-4">Speakers</h1>
+      <p className="mb-4">
+        {speakers.length} unique speakers across{" "}
+        {speakers.reduce((a, b) => a + b.count, 0)} transcripts
+      </p>
+
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+        {speakers.map((speaker) => (
+          <Link
+            key={speaker.slug}
+            href={`/speakers/${speaker.slug}`}
+            className="flex justify-between items-center p-2 bg-gray-100 border border-gray-300 rounded"
+          >
+            <span>{speaker.fullName}</span>
+            <span>{speaker.count}</span>
+          </Link>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/app/tags/[tag]/page.tsx
+++ b/src/app/tags/[tag]/page.tsx
@@ -1,0 +1,33 @@
+import React from "react";
+import Link from "next/link";
+import { allTranscripts } from "contentlayer/generated";
+
+export async function generateStaticParams() {
+  const tags = Array.from(
+    new Set(allTranscripts.flatMap((transcript) => transcript.tags))
+  );
+
+  return tags.map((tag) => ({
+    tag: tag,
+  }));
+}
+
+export default function TagPage({ params }: { params: { tag: string } }) {
+  const { tag } = params;
+  const transcripts = allTranscripts
+    .filter((transcript) => transcript.tags?.includes(tag))
+    .map(({ title, url }) => ({ title, url }));
+
+  return (
+    <div>
+      <h1>Transcripts tagged with "{tag}"</h1>
+      <ul>
+        {transcripts.map((transcript) => (
+          <li key={transcript.url}>
+            <Link href={transcript.url}>{transcript.title}</Link>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/src/app/tags/page.tsx
+++ b/src/app/tags/page.tsx
@@ -1,0 +1,48 @@
+import Link from "next/link";
+import { allTranscripts } from "contentlayer/generated";
+import { getCategories, organizeTags } from "@/utils/fetchCategories";
+
+export default function TagsPage() {
+  const categories = getCategories();
+  const { tagsByCategory } = organizeTags(allTranscripts, categories);
+
+  const uniqueCategories = Object.keys(tagsByCategory).sort((a, b) =>
+    a === "Miscellaneous" ? 1 : b === "Miscellaneous" ? -1 : a.localeCompare(b)
+  );
+
+  return (
+    <div className="container mx-auto px-4 py-8">
+      <h1 className="text-3xl font-bold mb-4">Tags</h1>
+      <p className="mb-4">
+        {uniqueCategories.length} categories for{" "}
+        {Object.values(tagsByCategory).reduce(
+          (acc, arr) => acc + arr.length,
+          0
+        )}{" "}
+        unique tags
+      </p>
+
+      {uniqueCategories.map((category) => (
+        <div key={category} className="mb-8">
+          <h2 className="text-2xl font-semibold mb-4">{category}</h2>
+          <div className="grid grid-cols-2 gap-4">
+            {tagsByCategory[category].map((tag) => {
+              const linkHref = `/tags/${tag.slug}`;
+
+              return (
+                <Link
+                  key={tag.slug}
+                  href={linkHref}
+                  className="flex justify-between items-center p-2 bg-gray-100 border border-gray-300 rounded"
+                >
+                  <span>{tag.title}</span>
+                  <span>{tag.count}</span>
+                </Link>
+              );
+            })}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/utils/fetchCategories.ts
+++ b/src/utils/fetchCategories.ts
@@ -1,0 +1,99 @@
+import { Transcript } from "contentlayer/generated";
+import fs from "fs";
+import path from "path";
+import { getTags } from "@/utils";
+
+export interface CategoryInfo {
+  title: string;
+  slug: string;
+  optech_url: string;
+  categories: string[];
+  aliases?: string[];
+  excerpt: string;
+}
+
+interface TagInfo {
+  title: string;
+  slug: string;
+  count: number;
+}
+
+export function getCategories(): CategoryInfo[] {
+  const filePath = path.join(process.cwd(), "public", "categories.json");
+  const fileContents = fs.readFileSync(filePath, "utf8");
+  return JSON.parse(fileContents);
+}
+
+export function organizeTags(
+  transcripts: Transcript[],
+  categories: CategoryInfo[]
+) {
+  const tagsByCategory: { [category: string]: TagInfo[] } = {};
+  const tagsWithoutCategory = new Set<string>();
+
+  // Load the precomputed tag counts
+  const tagCounts = getTags();
+  const categorizedTags = new Set<string>();
+
+  // Initialize categories
+  categories.forEach((cat) => {
+    cat.categories.forEach((category) => {
+      if (!tagsByCategory[category]) {
+        tagsByCategory[category] = [];
+      }
+    });
+  });
+
+  // Categorize tags
+  transcripts.forEach((transcript) => {
+    const tags = transcript.tags || [];
+    tags.forEach((tag) => {
+      let categorized = false;
+      categories.forEach((catInfo) => {
+        if (
+          catInfo.slug === tag ||
+          (catInfo.aliases && catInfo.aliases.includes(tag))
+        ) {
+          catInfo.categories.forEach((category) => {
+            if (!tagsByCategory[category].some((t) => t.slug === tag)) {
+              tagsByCategory[category].push({
+                title: catInfo.title,
+                slug: tag,
+                count: tagCounts[tag] || 0,
+              });
+            }
+          });
+          categorized = true;
+          categorizedTags.add(tag);
+        }
+      });
+      if (!categorized) {
+        tagsWithoutCategory.add(tag);
+      }
+    });
+  });
+
+  // TODO: Implement logic for handling miscellaneous/catch-all tags for specific categories
+  // When a transcript belongs to a category but doesn't have a specific tag under that category,
+  // assign it to the category by using a category-specific miscellaneous tag.
+  // This will ensure that transcripts are properly categorized even when they don't match
+  // existing specific tags within a category.
+
+  // Add "Miscellaneous" category with remaining uncategorized tags
+  if (tagsWithoutCategory.size > 0) {
+    tagsByCategory["Miscellaneous"] = Array.from(tagsWithoutCategory).map(
+      (tag) => ({
+        title: tag,
+        slug: tag,
+        count: tagCounts[tag] || 0,
+      })
+    );
+  }
+
+  // Sort tags alphabetically within each category
+  Object.keys(tagsByCategory).forEach((category) => {
+    tagsByCategory[category].sort((a, b) => a.title.localeCompare(b.title));
+  });
+
+  return { tagsByCategory, tagsWithoutCategory };
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,4 +1,6 @@
 import type { Transcript } from "contentlayer/generated";
+import fs from "fs";
+import path from "path";
 
 export interface ContentTree {
   [key: string]: ContentTree | Transcript[];
@@ -26,4 +28,40 @@ export function organizeContent(transcripts: Transcript[]): ContentTree {
   });
 
   return tree;
+}
+
+export function createSlug(name: string): string {
+  return name
+    .toLowerCase()
+    .replace(/\s+/g, "-") // Replace spaces with -
+    .replace(/[^\w\-]+/g, "") // Remove all non-word chars
+    .replace(/\-\-+/g, "-") // Replace multiple - with single -
+    .replace(/^-+/, "") // Trim - from start of text
+    .replace(/-+$/, ""); // Trim - from end of text
+}
+
+interface SpeakerData {
+  count: number;
+  fullName: string;
+}
+
+export function getSpeakers(): {
+  [key: string]: SpeakerData;
+} {
+  const filePath = path.join(process.cwd(), "public", "speaker-data.json");
+  const fileContents = fs.readFileSync(filePath, "utf8");
+  return JSON.parse(fileContents);
+}
+
+// Helper function to read speaker data from JSON file
+export function getSpeakerData(slug: string): SpeakerData | null {
+  return getSpeakers()[slug] || null;
+}
+
+export function getTags(): {
+  [key: string]: number;
+} {
+  const filePath = path.join(process.cwd(), "public", "tag-data.json");
+  const fileContents = fs.readFileSync(filePath, "utf8");
+  return JSON.parse(fileContents);
 }


### PR DESCRIPTION
This is an attempt to replicate the current information architecture that we currently have in https://github.com/bitcointranscripts/bitcointranscripts.github.io

This is definitely not finalized, but it's a good start. Most of the discrepancies that exist in the `/tags` page (You can see them in the "Miscellaneous" section at the end of the page) will be fixed with the refinement of the existing tags on the individual transcripts.