### PR TITLE
Fix: Relative links and exhaustive pattern matching.

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -5,8 +5,8 @@ const nextConfig = {
     return {
       fallback: [
         {
-          source: "/plugins/:path*",
-          destination: "/gh-pages/plugins/:path*",
+          source: '/:path*.:ext([^/]+)', // intercept all paths ending with a file extension
+          destination: '/gh-pages/:path*.:ext', // rewrite to gh-pages/[path_here].ext
         },
         {
           source: "/:path*",

--- a/src/components/layout/FooterComponent.tsx
+++ b/src/components/layout/FooterComponent.tsx
@@ -20,7 +20,7 @@ const FooterComponent = () => {
             </p>
           </section>
           <section className='flex flex-col gap-12 text-black font-bold text-xl underline max-xl:text-base max-xl:gap-8 max-md:gap-4'>
-            <Link href='https://btctranscripts.com/' target='_blank'>
+            <Link href='/transcripts'>
               Transcripts
             </Link>
             <Link href='/About' className='hidden'>

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -207,8 +207,8 @@ const Header = () => {
           <ThemeSwitcher />
         </div>
         <nav className='md:flex items-center gap-16 text-black max-xl:gap-4 max-lg:text-sm max-md:hidden'>
-          <Link href='https://btctranscripts.com/'>Transcripts</Link>
-          <Link href='/transcripts' className='hidden'>
+          <Link href='/transcripts'>Transcripts</Link>
+          <Link href='/about' className='hidden'>
             About
           </Link>
         </nav>


### PR DESCRIPTION
Two fixes
- some links were hard coded to `https://btctranscripts.com/`, this changes it to `/transcripts`. Keeps the homepage in the same domain.
- the `index.html` file from `gh-pages` submodule and other built pages contain links to absolute path, i.e `https://btctranscripts.com/...` for example `https://btctranscripts.com/lib/jquery.min.js`. 
Given that we will change the current domain to point at this build instead of `gh-pages` static pages, `https://btctranscripts.com/lib/jquery.min.js` must resolve to a valid file. Hence the PR introduces pattern matching in the fall back that checks the `public/gh-pages` submodule as a last option to ensure these files can be gotten.
The same applies to static output like `https://btctranscripts.com/status.json` etc
Ideally they should be built from nextJs but that will roll in incrementally, while this pattern serves those files to whoever needs them.,
