### PR TITLE
fix: scroll, header and add footer

### DIFF
--- a/src/app/(explore)/layout.tsx
+++ b/src/app/(explore)/layout.tsx
@@ -9,15 +9,15 @@ export default function ExploreLayout({
 }) {
   return (
     <>
-      <Wrapper>
-        <section className="flex gap-[50px] md:pb-[100px] pt-2 md:pt-6">
+      <section className="pt-2 md:pt-6 h-[calc(100vh-var(--header-height)-10px)] overflow-y-auto">
+        <Wrapper className="flex gap-[50px] md:pb-[100px]">
           <ExploreNavigation />
           <div className="w-full scroll-smooth">{children}</div>
 
           {/* Include shared UI here e.g. a header or sidebar */}
-        </section>
-      </Wrapper>
-      <FooterComponent />
+        </Wrapper>
+        <FooterComponent />
+      </section>
     </>
   );
 }

--- a/src/app/(explore)/layout.tsx
+++ b/src/app/(explore)/layout.tsx
@@ -1,4 +1,6 @@
 import ExploreNavigation from "@/components/explore/ExploreNavigation";
+import FooterComponent from "@/components/layout/FooterComponent";
+import Wrapper from "@/components/layout/Wrapper";
 
 export default function ExploreLayout({
   children, // will be a page or nested layout
@@ -6,13 +8,16 @@ export default function ExploreLayout({
   children: React.ReactNode;
 }) {
   return (
-    <div className="w-full max-w-[1920px] mx-auto px-4 lg:px-10 2xl:px-[60px]">
-      <section className="flex  gap-[50px] h-[calc(100vh-var(--header-height))]  pt-6 overflow-y-auto ">
-        <ExploreNavigation />
-        <div className="max-h-full h-full w-full scroll-smooth overflow-scroll ">{children}</div>
+    <>
+      <Wrapper>
+        <section className="flex gap-[50px] md:pb-[100px] pt-2 md:pt-6">
+          <ExploreNavigation />
+          <div className="w-full scroll-smooth">{children}</div>
 
-        {/* Include shared UI here e.g. a header or sidebar */}
-      </section>
-    </div>
+          {/* Include shared UI here e.g. a header or sidebar */}
+        </section>
+      </Wrapper>
+      <FooterComponent />
+    </>
   );
 }

--- a/src/app/(explore)/sources/[...slug]/page.tsx
+++ b/src/app/(explore)/sources/[...slug]/page.tsx
@@ -62,8 +62,8 @@ const page = ({ params }: { params: { slug: string[] } }) => {
   const isDirectoryList = Array.isArray(current);
 
   return (
-    <div className='flex items-start lg:gap-[50px] max-h-[calc(100vh-var(--header-height)-24px)]'>
-      <div className='flex flex-col w-full gap-6 md:gap-8 2xl:gap-10 no-scrollbar max-h-[calc(100vh-var(--header-height)-24px)]'>
+    <div className='flex items-start lg:gap-[50px]'>
+      <div className='flex flex-col w-full gap-6 md:gap-8 2xl:gap-10 no-scrollbar'>
         <div
           className={`flex flex-col ${
             isDirectoryList ? "border-b border-b-[#9B9B9B] pb-6 md:border-b-0 md:pb-0" : "border-b border-b-[#9B9B9B] pb-6 lg:pb-10"
@@ -101,7 +101,7 @@ const page = ({ params }: { params: { slug: string[] } }) => {
             ))}
           </div>
         ) : (
-          <div className='flex-col flex gap-10 max-h-[calc(100vh-var(--header-height)-24px)] overflow-scroll pb-8'>
+          <div className='flex-col flex gap-10 overflow-scroll pb-8'>
             <div className='grid grid-cols-1 sm:grid-cols-2 gap-2.5'>
               {(displayCurrent as string[]).map((key, i) => (
                 <Link

--- a/src/app/(explore)/template.tsx
+++ b/src/app/(explore)/template.tsx
@@ -9,7 +9,7 @@ export default function ExploreLayout({
 }) {
   return (
     <>
-      <section className="pt-2 md:pt-6 h-[calc(100vh-var(--header-height)-10px)] overflow-y-auto">
+      <section className="mt-2 md:mt-6 h-[calc(100vh-var(--header-height)-26px)] overflow-y-auto">
         <Wrapper className="flex gap-[50px] md:pb-[100px]">
           <ExploreNavigation />
           <div className="w-full scroll-smooth">{children}</div>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -32,7 +32,7 @@
   --background-start-rgb: 214, 219, 220;
   --background-end-rgb: 255, 255, 255;
   --basic-mono-font: basic-mono;
-  --header-height: 100px;
+  --header-height: 86px;
 }
 
 /* @media (prefers-color-scheme: dark) {
@@ -49,6 +49,11 @@ body {
   color: rgb(var(--foreground-rgb));
 } */
 
+@media (min-width: 768px) {
+  :root {
+    --header-height: 100px;
+  }
+}
 
 @layer utilities {
   .text-balance {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -24,7 +24,7 @@ export default function RootLayout({
     <html lang='en'>
       <body className={manrope.className}>
         <Header />
-        <div>{children}</div>
+        {children}
       </body>
       <Script async src='https://visits.bitcoindevs.xyz/script.js' data-website-id='06384ada-7f1c-44c2-a6d9-d830fb23e122'></Script>
     </html>

--- a/src/components/common/BreadCrumbs.tsx
+++ b/src/components/common/BreadCrumbs.tsx
@@ -12,8 +12,7 @@ const BreadCrumbs = () => {
       .split("/")
       .slice(0, idx + 1)
       .join("/");
-
-    return { name: path || "home", link: route };
+    return { name: path || "home", link: route || "/" };
   });
 
   const isActive = allRoutes[allRoutes.length - 1];

--- a/src/components/explore/ExploreNavigation.tsx
+++ b/src/components/explore/ExploreNavigation.tsx
@@ -7,7 +7,7 @@ import { ArrowLinkUpRight } from "@bitcoin-dev-project/bdp-ui/icons";
 
 const ExploreNavigation = () => {
   return (
-    <section className='hidden md:flex sticky top-[calc(var(--header-height)+24px)] overflow-y-auto flex-col self-start gap-4 2xl:gap-6 w-full max-w-[240px] 2xl:max-w-[320px]'>
+    <section className='hidden md:flex sticky top-0 overflow-y-auto flex-col self-start gap-4 2xl:gap-6 w-full max-w-[240px] 2xl:max-w-[320px]'>
       <div className='flex flex-col gap-4 2xl:gap-6 rounded-lg px-5 py-[23px] border border-gray-custom-1200'>
         {ExploreNavigationItems.map((item) => (
           <ExploreNavigationItem key={item.href} href={item.href} title={item.title} />

--- a/src/components/explore/ExploreNavigation.tsx
+++ b/src/components/explore/ExploreNavigation.tsx
@@ -7,7 +7,7 @@ import { ArrowLinkUpRight } from "@bitcoin-dev-project/bdp-ui/icons";
 
 const ExploreNavigation = () => {
   return (
-    <section className='max-md:hidden md:flex sticky top-0 flex-col flex-none gap-4  2xl:gap-6  w-full max-w-[240px] 2xl:max-w-[320px]'>
+    <section className='hidden md:flex sticky top-[calc(var(--header-height)+24px)] overflow-y-auto flex-col self-start gap-4 2xl:gap-6 w-full max-w-[240px] 2xl:max-w-[320px]'>
       <div className='flex flex-col gap-4 2xl:gap-6 rounded-lg px-5 py-[23px] border border-gray-custom-1200'>
         {ExploreNavigationItems.map((item) => (
           <ExploreNavigationItem key={item.href} href={item.href} title={item.title} />

--- a/src/components/explore/TranscriptContentPage.tsx
+++ b/src/components/explore/TranscriptContentPage.tsx
@@ -24,7 +24,7 @@ const TranscriptContentPage: FC<ITranscriptContentPage> = ({ header, data, descr
   return (
     <div className='flex items-start relative lg:gap-[50px]'>
       <div className='flex flex-col w-full gap-6 lg:gap-10 no-scrollbar'>
-        <div className='block lg:hidden sticky top-[calc(var(--header-height))]'>
+        <div className='block lg:hidden sticky top-0'>
           {type == "alphabet" && <MobileAlphabetGrouping currentGroup={currentGroup} groupedData={groupedData} />}
           {type == "words" && <ContentGrouping groupedData={groupedData} currentGroup={currentGroup} screen='mobile' />}
         </div>
@@ -64,7 +64,7 @@ const TranscriptContentPage: FC<ITranscriptContentPage> = ({ header, data, descr
         </div>
       </div>
 
-      <div className='hidden lg:flex sticky top-[calc(var(--header-height)+24px)] self-start flex-shrink-0 w-fit lg:justify-center '>
+      <div className='hidden lg:flex sticky top-0 self-start flex-shrink-0 w-fit lg:justify-center '>
         {type === "alphabet" && <AlphabetGrouping groupedData={groupedData} currentGroup={currentGroup} />}
         {type == "words" && <ContentGrouping groupedData={groupedData} currentGroup={currentGroup} screen='desktop' />}
       </div>

--- a/src/components/explore/TranscriptContentPage.tsx
+++ b/src/components/explore/TranscriptContentPage.tsx
@@ -22,9 +22,9 @@ const TranscriptContentPage: FC<ITranscriptContentPage> = ({ header, data, descr
   const [currentGroup, setCurrentGroup] = useState<string>(type === "alphabet" ? "A" : createSlug(Object.keys(groupedData)[0]));
 
   return (
-    <div className='flex  items-start  relative  lg:gap-[50px] '>
+    <div className='flex items-start relative lg:gap-[50px]'>
       <div className='flex flex-col w-full gap-6 lg:gap-10 no-scrollbar'>
-        <div className='block lg:hidden sticky top-0 '>
+        <div className='block lg:hidden sticky top-[calc(var(--header-height))]'>
           {type == "alphabet" && <MobileAlphabetGrouping currentGroup={currentGroup} groupedData={groupedData} />}
           {type == "words" && <ContentGrouping groupedData={groupedData} currentGroup={currentGroup} screen='mobile' />}
         </div>
@@ -64,7 +64,7 @@ const TranscriptContentPage: FC<ITranscriptContentPage> = ({ header, data, descr
         </div>
       </div>
 
-      <div className='hidden lg:flex sticky top-0 flex-shrink-0  w-fit lg:justify-center '>
+      <div className='hidden lg:flex sticky top-[calc(var(--header-height)+24px)] self-start flex-shrink-0 w-fit lg:justify-center '>
         {type === "alphabet" && <AlphabetGrouping groupedData={groupedData} currentGroup={currentGroup} />}
         {type == "words" && <ContentGrouping groupedData={groupedData} currentGroup={currentGroup} screen='desktop' />}
       </div>

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -189,7 +189,9 @@ const Header = () => {
     <div className='flex items-center justify-center border-b-[0.5px] border-b-gray-custom-200 max-md:border-b-0 w-full sticky top-0 z-20'>
       <Wrapper className='h-[var(--header-height)] flex items-center w-full justify-between bg-white sticky top-0 z-20 gap-6 max-lg:gap-4 max-md:h-[86px]'>
         <section className='flex items-center gap-16 max-xl:gap-8 max-lg:gap-4'>
-          <Logo iconStyles='w-9 max-xl:w-[30px]' textStyles='text-black text-[24px] leading-[36.77px] max-lg:text-base' />
+          <Link href="/">
+            <Logo iconStyles='w-9 max-xl:w-[30px]' textStyles='text-black text-[24px] leading-[36.77px] max-lg:text-base' />
+          </Link>
           <nav className='md:hidden items-center gap-16 text-black max-xl:gap-4 max-lg:text-sm max-md:hidden'>
             <Link href='/categories'>Transcripts</Link>
             <Link href='/about' className='hidden'>

--- a/src/components/layout/Wrapper.tsx
+++ b/src/components/layout/Wrapper.tsx
@@ -1,5 +1,5 @@
 import React from "react";
 
 export default function Wrapper({ className, ...props }: React.ComponentPropsWithoutRef<"div">) {
-  return <div className={`px-[60px] max-xl:px-5 max-lg:px-4 max-w-[1920px] ${className}`} {...props} />;
+  return <div className={`w-full max-w-[1920px] px-4 lg:px-10 2xl:px-[60px] mx-auto ${className}`} {...props} />;
 }


### PR DESCRIPTION
fixes:
- scroll entire page rather than fixed height in scrollable area
- dynamic header height based on media query
- add footer to explore layout
- clickable icon to base route
- reuse wrapper for layout