### PR TITLE
Point submodule to main branch

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5,7 +5,3 @@
 	path = public/gh-pages
 	url = https://github.com/bitcointranscripts/bitcointranscripts.github.io.git
 	branch = gh-pages
-[submodule "public/refine-taxonomies"]
-	path = public/refine-taxonomies
-	url = https://github.com/kouloumos/bitcointranscripts
-	branch = refine-taxonomies

--- a/contentlayer.config.ts
+++ b/contentlayer.config.ts
@@ -354,7 +354,7 @@ export const Source = defineDocumentType(() => ({
 }));
 
 export default makeSource({
-  contentDirPath: path.join(process.cwd(), "public", "refine-taxonomies"),
+  contentDirPath: path.join(process.cwd(), "public", "bitcoin-transcript"),
   documentTypes: [Source, Transcript],
   contentDirExclude: [
     ".github",


### PR DESCRIPTION
This pr points the contentlayer config to the main branch in btctranscripts.com, deletes the refine-taxonomies submodule setup which was used for testing