### PR TITLE
fix(contentlayer): Improve Topics Processing and Generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,9 +21,9 @@
 /build
 /public/categories.json
 /public/types-data.json
-/public/tag-data.json
+/public/topics-by-category-counts.json
 /public/aliases.json
-/public/topics-data.json
+/public/topics-counts.json
 /public/speaker-data.json
 /public/source-count-data.json
 /public/sources-data.json

--- a/contentlayer.config.ts
+++ b/contentlayer.config.ts
@@ -120,13 +120,23 @@ function generateCategorizedList(processedTopics: Map<string, ProcessedTopic>): 
       if (!categorizedTopics[category]) {
         categorizedTopics[category] = [];
       }
-      categorizedTopics[category].push({ name, slug, count });
+      
+      // Check if topic name contains category name and ends with "(Miscellaneous)"
+      const modifiedName = name.includes(category) && name.endsWith("(Miscellaneous)") 
+        ? "Miscellaneous"
+        : name;
+      
+      categorizedTopics[category].push({ name: modifiedName, slug, count });
     });
   });
 
   // Sort topics within each category
   Object.values(categorizedTopics).forEach(topics => {
-    topics.sort((a, b) => a.name.localeCompare(b.name));
+    topics.sort((a, b) => {
+      if (a.name == "Miscellaneous") return 1;
+      if (b.name == "Miscellaneous") return -1;
+      return a.name.localeCompare(b.name)
+    });
   });
 
   return categorizedTopics;

--- a/contentlayer.config.ts
+++ b/contentlayer.config.ts
@@ -19,13 +19,21 @@ const Resources = defineNestedType(() => ({
     url: { type: "string" },
   },
 }));
-export interface CategoryInfo {
+export interface Topic {
   title: string;
   slug: string;
   optech_url: string;
   categories: string[];
   aliases?: string[];
   excerpt: string;
+}
+
+// The full processed topic we use internally
+interface ProcessedTopic {
+  name: string;            // Display name (from topic.title or original tag)
+  slug: string;           // Slugified identifier
+  count: number;          // Number of occurrences
+  categories: string[];   // List of categories it belongs to
 }
 
 interface TagInfo {
@@ -55,91 +63,95 @@ const getTranscriptAliases = (allTranscripts: ContentTranscriptType[]) => {
   fs.writeFileSync("./public/aliases.json", JSON.stringify(aliases));
 };
 
-const getCategories = () => {
-  const filePath = path.join(process.cwd(), "public", "categories.json");
+const getTopics = () => {
+  const filePath = path.join(process.cwd(), "public", "topics.json");
   const fileContents = fs.readFileSync(filePath, "utf8");
   return JSON.parse(fileContents);
 };
 
-
-function generateTopicsCounts(transcripts: ContentTranscriptType[]) {
-  const categories: CategoryInfo[] = getCategories();
-  const topicsMap = new Map<string, TopicsData>();
-  const categoryMap = new Map<string, CategoryInfo>();
-  const topicsByCategory: { [category: string]: TopicsData[] } = {};
-  const uncategorizedTopics = new Set<string>();
-
-  // Initialize category map and category arrays
-  categories.forEach((cat) => {
-    cat.categories.forEach((category) => {
-      if (!topicsByCategory[category]) {
-        topicsByCategory[category] = [];
-      }
-    });
-    categoryMap.set(createSlug(cat.slug), cat);
-    cat.aliases?.forEach((alias) => categoryMap.set(alias, cat));
+function buildTopicsMap(transcripts: ContentTranscriptType[], topics: Topic[]): Map<string, ProcessedTopic> {
+  // Create topics lookup map (includes aliases)
+  const topicsLookup = new Map<string, Topic>();
+  topics.forEach(topic => {
+    topicsLookup.set(topic.slug, topic);
+    topic.aliases?.forEach(alias => topicsLookup.set(alias, topic));
   });
 
-  // Process all transcripts to build topic counts and names
-  transcripts.forEach((transcript) => {
-    transcript.tags?.forEach((tag) => {
+  // Build the main topics map
+  const processedTopics = new Map<string, ProcessedTopic>();
+
+  // Process all transcripts
+  transcripts.forEach(transcript => {
+    transcript.tags?.forEach(tag => {
       const slug = createSlug(tag);
-      
-      if (!topicsMap.has(slug)) {
-        // Get the proper name from categories if it exists
-        const categoryInfo = categoryMap.get(slug);
-        const name = categoryInfo ? categoryInfo.title : tag;
-        
-        topicsMap.set(slug, {
-          name,
+      const topic = topicsLookup.get(slug);
+
+      if (!processedTopics.has(slug)) {
+        processedTopics.set(slug, {
+          name: topic?.title || tag,
           slug,
-          count: 1
+          count: 1,
+          categories: topic?.categories || ["Miscellaneous"],
         });
       } else {
-        const topicInfo = topicsMap.get(slug)!;
-        topicInfo.count += 1;
+        const processed = processedTopics.get(slug)!;
+        processed.count += 1;
       }
     });
   });
 
-  // Organize topics into categories
-  topicsMap.forEach((topicInfo, slug) => {
-    const categoryInfo = categoryMap.get(slug);
-    
-    if (categoryInfo) {
-      categoryInfo.categories.forEach((category) => {
-        topicsByCategory[category].push(topicInfo);
-      });
-    } else {
-      uncategorizedTopics.add(slug);
-    }
-  });
+  return processedTopics;
+}
 
-  // Add miscellaneous category
-  if (uncategorizedTopics.size > 0) {
-    topicsByCategory["Miscellaneous"] = Array.from(uncategorizedTopics)
-      .map(slug => topicsMap.get(slug)!)
-      .sort((a, b) => a.name.localeCompare(b.name));
+function generateAlphabeticalList(processedTopics: Map<string, ProcessedTopic>): TopicsData[] {
+  const result: TopicsData[] = [];
+  // The categories property is not needed for this list, so we drop it
+  for (const { name, slug, count } of processedTopics.values()) {
+    result.push({ name, slug, count });
   }
+  return result.sort((a, b) => a.name.localeCompare(b.name));
+}
+
+function generateCategorizedList(processedTopics: Map<string, ProcessedTopic>): Record<string, TopicsData[]> {
+  const categorizedTopics: Record<string, TopicsData[]> = {};
+
+  Array.from(processedTopics.values()).forEach(({ name, slug, count, categories }) => {
+    categories.forEach(category => {
+      if (!categorizedTopics[category]) {
+        categorizedTopics[category] = [];
+      }
+      categorizedTopics[category].push({ name, slug, count });
+    });
+  });
 
   // Sort topics within each category
-  Object.keys(topicsByCategory).forEach((category) => {
-    topicsByCategory[category].sort((a, b) => a.name.localeCompare(b.name));
+  Object.values(categorizedTopics).forEach(topics => {
+    topics.sort((a, b) => a.name.localeCompare(b.name));
   });
 
-  // Create alphabetical list of all topics
-  const allTopicsArray = Array.from(topicsMap.values())
-    .sort((a, b) => a.name.localeCompare(b.name));
+  return categorizedTopics;
+}
 
-  // Write both JSON files
+function generateTopicsCounts(transcripts: ContentTranscriptType[]) {
+  // Get topics
+  const topics = getTopics();
+
+  // Build the primary data structure
+  const processedTopics = buildTopicsMap(transcripts, topics);
+
+  // Generate both output formats
+  const alphabeticalList = generateAlphabeticalList(processedTopics);
+  const categorizedList = generateCategorizedList(processedTopics);
+
+  // Write output files
   fs.writeFileSync(
-    "./public/topics-by-category-counts.json", 
-    JSON.stringify(topicsByCategory, null, 2)
+    "./public/topics-counts.json",
+    JSON.stringify(alphabeticalList, null, 2)
   );
-  
+
   fs.writeFileSync(
-    "./public/topics-counts.json", 
-    JSON.stringify(allTopicsArray, null, 2)
+    "./public/topics-by-category-counts.json",
+    JSON.stringify(categorizedList, null, 2)
   );
 }
 

--- a/package.json
+++ b/package.json
@@ -4,9 +4,9 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "fetch-categories": "node scripts/fetchCategories.js",
+    "fetch-topics": "node scripts/fetchTopics.js",
     "submodules:update": "git submodule update --init && git submodule update --remote",
-    "build": "npm run submodules:update && npm run fetch-categories && next build",
+    "build": "npm run submodules:update && npm run fetch-topics && next build",
     "start": "next start",
     "lint": "next lint"
   },

--- a/scripts/fetchTopics.js
+++ b/scripts/fetchTopics.js
@@ -3,7 +3,7 @@ const path = require("path");
 const https = require("https");
 
 const url = "https://bitcoinops.org/topics.json";
-const outputPath = path.join(__dirname, "..", "public", "categories.json");
+const outputPath = path.join(__dirname, "..", "public", "topics.json");
 
 https
   .get(url, (res) => {
@@ -15,9 +15,9 @@ https
 
     res.on("end", () => {
       fs.writeFileSync(outputPath, data);
-      console.log("Categories data has been fetched and saved to public folder.");
+      console.log("Topics data has been fetched and saved to public folder.");
     });
   })
   .on("error", (err) => {
-    console.error("Error fetching categories:", err.message);
+    console.error("Error fetching topics:", err.message);
   });

--- a/scripts/fetchTopics.js
+++ b/scripts/fetchTopics.js
@@ -2,7 +2,7 @@ const fs = require("fs");
 const path = require("path");
 const https = require("https");
 
-const url = "https://bitcoinops.org/topics.json";
+const url = "https://raw.githubusercontent.com/bitcoinsearch/topics-index/refs/heads/main/topics.json";
 const outputPath = path.join(__dirname, "..", "public", "topics.json");
 
 https

--- a/src/app/(explore)/categories/page.tsx
+++ b/src/app/(explore)/categories/page.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import TranscriptContentPage from "@/components/explore/TranscriptContentPage";
-import allCategoriesTopic from "@/public/tag-data.json";
+import allCategoriesTopic from "@/public/topics-by-category-counts.json";
 
 const CategoriesPage = () => {
 

--- a/src/app/(explore)/topics/page.tsx
+++ b/src/app/(explore)/topics/page.tsx
@@ -1,9 +1,8 @@
 import React from "react";
 import TranscriptContentPage from "@/components/explore/TranscriptContentPage";
-import allTopics from "@/public/topics-data.json";
+import allTopics from "@/public/topics-counts.json";
 
 const TopicsPage = () => {
-  
   return (
     <div className="flex flex-col  text-black">
         <TranscriptContentPage header="Topics" data={allTopics} description="Bitcoin is made up of an endless amount of topics, and there’s no shortage of rabbit holes to go down. "  type="alphabet" linkName="tags"/>

--- a/src/components/landing-page/explore-transcripts/ExploreTranscripts.tsx
+++ b/src/components/landing-page/explore-transcripts/ExploreTranscripts.tsx
@@ -5,7 +5,7 @@ import Wrapper from "@/components/layout/Wrapper";
 import ExploreTranscriptClient from "./ExploreTranscriptClient";
 
 function getTags() {
-  const filePath = path.join(process.cwd(), "public", "tag-data.json");
+  const filePath = path.join(process.cwd(), "public", "topics-by-category-counts.json");
   const fileContents = fs.readFileSync(filePath, "utf8");
   return JSON.parse(fileContents);
 }


### PR DESCRIPTION
This PR fixes #54 and and introduces improvements to the structure and handling of topic data in the content layer.

#### **Key Changes**    
- Simplify topics data generation while resolving the inconsistencies in topic names on the `/categories` and `/topics` pages.
 - Transitioned to using our [own topics index](https://github.com/bitcoinsearch/topics-index), replacing reliance on Optech's.  
- Renamed JSON outputs for better understanding:  
   - `tag-data.json` → `topics-by-category-counts.json`  
   - `topics-data.json` → `topics-counts.json`  
- Added enhanced display options for miscellaneous topics.  
