### PR TITLE
fix: banner overflow on home page

### DIFF
--- a/src/components/banner/BossBanner.tsx
+++ b/src/components/banner/BossBanner.tsx
@@ -8,7 +8,7 @@ const BossBanner = () => {
   const pathname = usePathname()
   const isHome = pathname === "/"
   return (
-    <div className={`w-full bg-bdp-background sticky top-[var(--header-height)] z-40 ${!isHome ? "hidden" : ""}`}>
+    <div className={`w-full bg-bdp-background sticky top-[var(--header-height)] z-[15] ${!isHome ? "hidden" : ""}`}>
       <Banner
         headingText="Start your career in bitcoin open source —"
         linkText="APPLY TODAY"


### PR DESCRIPTION
A hot fix from the call, where the banner came over the appmenu.

<img width="1440" alt="Screenshot 2024-12-17 at 17 54 13" src="https://github.com/user-attachments/assets/59fd538e-46dc-4b68-908f-bbedfbca0122" />
