### PR TITLE
fix: sources and status json

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -5,6 +5,14 @@ const nextConfig = {
     return {
       fallback: [
         {
+          source: "/sources.json",
+          destination: "/gh-pages/sources.json",
+        },  
+        {
+          source: "/status.json",
+          destination: "/gh-pages/status.json",
+        },  
+        {
           source: "/:path((?!.*\\.[a-zA-Z0-9]{1,4}$).*)", // Matches paths without a valid file extension
           destination: "/transcript/:path*", // Rewrite to /transcripts/[path...]
         },


### PR DESCRIPTION
This PR should close #87,

Description

when the new website PR was merged status.json and sources.json couldn't be accessed.
This PR makes them accessible through the `/sources.json` route and  `/status.json`